### PR TITLE
New version 0.2 which also save the Request

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,2 @@
+Alexander Artemenko <svetlyak.40wt@gmail.com>
+Stéphane Angel <s.angel@twidi.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,14 @@
 ChangeLog for django-globals
 ============================
 
+0.2.0
+-----
+
+* The middleware now save the user AND the request.
+* The `django_globals.middleware.User` middleware is replaced by the
+`django_globals.middleware.Global` (but it's kept for retrocompatibility with
+a decrecation warning)
+
 0.1.0
 -----
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Django-globals, is a very simple application, that allow to define
 a thread specific global variables.
 
 Also, it includes a middleware User, which can be used, to access to
-the current user outside a view, when "request" variable is not
+the current request and user outside a view, when "request" variable is not
 defined.
 
 Installation
@@ -14,7 +14,7 @@ Installation
 Download sources, add place `django_globals` somewhere in yours python path.
 
 Next, add `django_globals` to the INSTALLED_APPS and, optionally,
-`django_globals.middleware.User` to the MIDDLEWARE_CLASSES.
+`django_globals.middleware.Global` to the MIDDLEWARE_CLASSES.
 
 Now you can make `from django_globals import globals` and access to
-the `globals.user` anywhere.
+the `globals.request` and `globals.user` anywhere.

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 setup(
     name = 'django-globals',
-    version = '0.1.0',
+    version = '0.2.0',
     description = 'Very simple application, that allow to define a thread specific global variables.',
     keywords = 'django apps',
     license = 'New BSD License',

--- a/src/django_globals/middleware.py
+++ b/src/django_globals/middleware.py
@@ -1,5 +1,18 @@
 from django_globals import globals
 
-class User:
+class Global(object):
     def process_request(self, request):
-        globals.user = request.user
+        globals.request = request
+        if hasattr(request, 'user'):
+            globals.user = request.user
+
+# retrocompatibility
+class User(Global):
+    def __init__(self, *args, **kwargs):
+        import warnings
+        warnings.warn(
+            'The `django_globals.middleware.User` middleware is deprecated, you should use `django_globals.middleware.Global`',
+            DeprecationWarning,
+            stacklevel=2
+        )
+        super(User, self).__init__(*args, **kwargs)


### PR DESCRIPTION
The middleware has a new name : `django_globals.middleware.Global` but
the old one is still here for retrocompatibility (with a deprecation
warning)

The request in globals can be usefull with the messages framework in
django to add messages without direct access to the request.
