### PR TITLE
Ability to execute `django_globals` outside Django context and lazy current user getter

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 Alexander Artemenko <svetlyak.40wt@gmail.com>
 Stéphane Angel <s.angel@twidi.com>
+Alexander Shvetsov <ashvetsov@definitif.ru>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,14 @@
 ChangeLog for django-globals
 ============================
 
+0.2.1
+-----
+
+* Request and user properties can now be accessed outside Django context
+or w/o `django_globals.middleware.Global` middleware.
+* Added lazy `get_current_user()` method to easier handle cases when user
+did change within request.
+
 0.2.0
 -----
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 setup(
     name = 'django-globals',
-    version = '0.2.0',
+    version = '0.2.1',
     description = 'Very simple application, that allow to define a thread specific global variables.',
     keywords = 'django apps',
     license = 'New BSD License',

--- a/src/django_globals/__init__.py
+++ b/src/django_globals/__init__.py
@@ -2,11 +2,15 @@ import threading
 globals = threading.local()
 
 
+def get_current_user():
+    """
+    Lazy request.user getter method.
+    """
+    return getattr(globals.request, 'user', None)
+
 # Setting placeholders for `request` and `user`
 # globals to allow calling them outside Django
 # context or w/o globals middleware.
 if not hasattr(globals, 'request'):
     globals.request = None
     globals.user = None
-
-    globals.get_current_user = get_current_user

--- a/src/django_globals/__init__.py
+++ b/src/django_globals/__init__.py
@@ -1,2 +1,12 @@
 import threading
 globals = threading.local()
+
+
+# Setting placeholders for `request` and `user`
+# globals to allow calling them outside Django
+# context or w/o globals middleware.
+if not hasattr(globals, 'request'):
+    globals.request = None
+    globals.user = None
+
+    globals.get_current_user = get_current_user

--- a/src/django_globals/middleware.py
+++ b/src/django_globals/middleware.py
@@ -1,9 +1,10 @@
-from django_globals import globals
+from django_globals import globals, get_current_user
 
 class Global(object):
     def process_request(self, request):
         globals.request = request
-        globals.user = getattr(request, 'user', None)
+        globals.user = get_current_user()
+
 
 # retrocompatibility
 class User(Global):


### PR DESCRIPTION
* Request and user properties can now be accessed outside Django context or w/o `django_globals.middleware.Global` middleware.
* Added lazy `get_current_user()` method to easier handle cases when user did change within request (authentication request or some sort of sudo-ing for instance).