### PR TITLE
Drop recommendation to add to INSTALLED_APPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ Installation
 
 Install `django_globals` using pip.
 
-Next, add `django_globals` to the INSTALLED_APPS and
-`django_globals.middleware.Global` to the MIDDLEWARE_CLASSES.
+Next, add `django_globals.middleware.Global` to the MIDDLEWARE_CLASSES.
 
 Now you can make `from django_globals import globals` and access to
 the `globals.request` and `globals.user` from anywhere.


### PR DESCRIPTION
Is not required to use a middleware. The app contains no URLs, models,
views, or template tags.