### PR TITLE
Remove unused, deprecated class django_globals.middleware.User

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,12 @@
 ChangeLog for django-globals
 ============================
 
+UNRELEASED
+----------
+
+* Removed deprecated `django_globals.middleware.User`. Use
+  `django_globals.middleware.Global` instead.
+
 0.2.1
 -----
 

--- a/src/django_globals/middleware.py
+++ b/src/django_globals/middleware.py
@@ -4,14 +4,3 @@ class Global(object):
     def process_request(self, request):
         globals.request = request
         globals.user = getattr(request, 'user', None)
-
-# retrocompatibility
-class User(Global):
-    def __init__(self, *args, **kwargs):
-        import warnings
-        warnings.warn(
-            'The `django_globals.middleware.User` middleware is deprecated, you should use `django_globals.middleware.Global`',
-            DeprecationWarning,
-            stacklevel=2
-        )
-        super(User, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Has been deprecated since 2011-09-08 in commit
3a2b4155d7ed28832ab8911602e85d53617675eb. Over 6 years ago.