### PR TITLE
refactor tests so they don't rely on data being present after process_response

### DIFF
--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,24 +1,33 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
-from django_globals import globals
-
 User = get_user_model()
 
 
 class TestMiddleware(TestCase):
+    """
+    Since the middleware doesn't preserve its contents after the request
+    we rely on views to perform the assertions
+    """
 
     def test_request(self):
-        self.client.get("/?foo=bar")
+        response = self.client.get("/assert-request")
 
-        self.assertEqual(dict(globals.request.GET.dict()), {"foo": "bar"})
+        self.assertEqual(response.status_code, 200)
+
+    def test_anon_user(self):
+        self.client.logout()
+
+        response = self.client.get("/assert-user")
+
+        self.assertEqual(response.status_code, 200)
 
     def test_user(self):
         user = User.objects.create_user(username='testuser', email='user@example.com', password='top_secret')
         self.client.login(username='testuser', password='top_secret')
 
-        self.client.get("/?foo=bar")
-        self.assertEqual(globals.user, user)
+        response = self.client.get("/assert-user")
+
+        self.assertEqual(response.status_code, 200)

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -3,8 +3,9 @@ from __future__ import unicode_literals, absolute_import
 
 from django.conf.urls import url
 
-from .views import simple_view
+from . import views
 
 urlpatterns = [
-    url(r'^', simple_view),
+    url(r'^assert-request', views.assert_request_view),
+    url(r'^assert-user', views.assert_user_view),
 ]

--- a/tests/views.py
+++ b/tests/views.py
@@ -1,5 +1,27 @@
 from django.http import HttpResponse
 
+from django_globals import globals
 
-def simple_view(request):
+
+def assert_request_view(request):
+    """
+    View that asserts that the request object is accessible via globals
+    :param request:
+    :return:
+    """
+    if globals.request != request:
+        raise Exception("Expected request object in globals.request")
+
+    return HttpResponse("<html></html>")
+
+
+def assert_user_view(request):
+    """
+    View that asserts that the user object is accessible via globals
+    :param request:
+    :return:
+    """
+    if globals.user != request.user:
+        raise Exception("Expected user object in globals.user")
+
     return HttpResponse("<html></html>")


### PR DESCRIPTION
Fixes compatibility of tests from #11 with behaviour from #7