### PR TITLE
Configure Python 3.7 testing environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ python:
 - 2.7
 - pypy
 - pypy3
+# Current "official" way to configure Python 3.7 runtime in Travis using matrix include
+# based on https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905
+# shall be removed once Travis supports py37 in the normal way
 matrix:
   include:
     - language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,16 @@ deploy:
 install: pip install tox-travis
 language: python
 python:
-- 3.7-dev
 - 3.6
 - 3.5
 - 3.4
 - 2.7
 - pypy
 - pypy3
+matrix:
+  include:
+    - language: python
+      python: "3.7"
+      sudo: required
+      dist: xenial
 script: tox


### PR DESCRIPTION
Python 3.7-dev on Travis is outdated and doesn't reflect the actual final Python 3.7 version.

This Pull Request is based on current "official" way to configure Python 3.7 runtime in Travis
https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905

It seems like a hack, but at least it run the tests on correct Python 3.7 version.