### PR TITLE
add a wrapper class for threading that prevents errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ docs/_build
 
 # Vim
 .*.sw[op]
+
+#virtual environments
+/venv/

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,3 +3,4 @@ mock
 flake8
 tox
 codecov
+django

--- a/src/django_globals/__init__.py
+++ b/src/django_globals/__init__.py
@@ -1,3 +1,12 @@
 import threading
 
-globals = threading.local()
+
+class DjangoGlobal(threading.local):
+    user = None
+    request = None
+
+    def __init__(self, *args, **kwargs):
+        super(DjangoGlobal, self).__init__(*args, **kwargs)
+
+
+globals = DjangoGlobal()

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -3,6 +3,7 @@
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import TestCase
+from django_globals import globals
 
 User = get_user_model()
 
@@ -42,3 +43,7 @@ class TestMiddleware(TestCase):
         response = self.client.get("/assert-request")
 
         self.assertEqual(response.status_code, 301)
+
+    def test_startup(self):
+        self.assertTrue(globals.user is None, 'referenceing user outside of a view shouldn\' through an error')
+        self.assertTrue(globals.request is  None, 'referenceing user outside of a view shouldn\' through an error')


### PR DESCRIPTION
This change prevents an attribute error when  Django is starting up and globals is referenced in custom classes or forms.

Closes #28 